### PR TITLE
Creates dirs per db and populates with files

### DIFF
--- a/DocAggregatorDotnetCore/TomAggregator.cs
+++ b/DocAggregatorDotnetCore/TomAggregator.cs
@@ -19,11 +19,6 @@ namespace DocAggregatorDotnetCore
 
         public void DoSomeWork()
         {
-            var ctx = new RiggsTestContext();
-            var record = ctx.PropDocs.Find(1);
-
-            Console.WriteLine(record.PropRef);
-
 
             //get files to be processed
             var files = GetFiles(WorkingDirectory);
@@ -38,14 +33,21 @@ namespace DocAggregatorDotnetCore
 
             Directory.CreateDirectory(outputDirectoryPath);
 
-            //Console.WriteLine("New folders to go in: " + outputDirectoryPath);
+            //make array of property refs
+            var ctx = new RiggsTestContext();
+            var listOfDocs = ctx.PropDocs.Select(p => p).ToList();
+            var docsArray = listOfDocs.ToArray();
 
-            foreach (var file in fileInfos)
+
+            //new make directories
+            foreach (var item in docsArray)
             {
+                Console.WriteLine(item.PropRef);
                 //Console.WriteLine(file.Name.Substring(0, offset));
-                var propertyDirectory = Path.Combine(outputDirectoryPath, file.Name.Substring(0, offset));
+                var propertyDirectory = Path.Combine(outputDirectoryPath,item.PropRef.ToString());
                 Directory.CreateDirectory(propertyDirectory);
             }
+
 
             foreach (var file in fileInfos)
             {

--- a/DocAggregatorDotnetCore/TomAggregator.cs
+++ b/DocAggregatorDotnetCore/TomAggregator.cs
@@ -43,9 +43,10 @@ namespace DocAggregatorDotnetCore
 
             using (var ctx = new RiggsTestContext())
             {
-                var listOfDocs = ctx.PropDocs.AsNoTracking().ToList();
-                                            
-            //new make directories
+                var listOfDocs = ctx.PropDocs.AsNoTracking().Where(p => p.PropRef != null).ToList();
+                
+
+                //new make directories
                 foreach (var item in listOfDocs)
                 {
                     Console.WriteLine(item.PropRef);

--- a/DocAggregatorDotnetCore/TomAggregator.cs
+++ b/DocAggregatorDotnetCore/TomAggregator.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.IO;
 using System.IO.Compression;
 using DataAccessLayer;
+using Microsoft.EntityFrameworkCore;
 
 //Adding a comment just to enable New Features branch
 
@@ -34,20 +35,26 @@ namespace DocAggregatorDotnetCore
             Directory.CreateDirectory(outputDirectoryPath);
 
             //make array of property refs
-            var ctx = new RiggsTestContext();
-            var listOfDocs = ctx.PropDocs.Select(p => p).ToList();
-            var docsArray = listOfDocs.ToArray();
+            //var ctx = new RiggsTestContext();
+            //var listOfDocs = ctx.PropDocs.Select(p => p).ToList();
+            //var docsArray = listOfDocs.ToArray();
 
+            //Where(x => x.Name == null)
 
-            //new make directories
-            foreach (var item in docsArray)
+            using (var ctx = new RiggsTestContext())
             {
-                Console.WriteLine(item.PropRef);
-                //Console.WriteLine(file.Name.Substring(0, offset));
-                var propertyDirectory = Path.Combine(outputDirectoryPath,item.PropRef.ToString());
-                Directory.CreateDirectory(propertyDirectory);
+                var listOfDocs = ctx.PropDocs.AsNoTracking().ToList();
+                                            
+            //new make directories
+                foreach (var item in listOfDocs)
+                {
+                    Console.WriteLine(item.PropRef);
+                    //Console.WriteLine(file.Name.Substring(0, offset));
+                    var propertyDirectory = Path.Combine(outputDirectoryPath,item.PropRef.ToString());
+                    Directory.CreateDirectory(propertyDirectory);
+                }
+                
             }
-
 
             foreach (var file in fileInfos)
             {


### PR DESCRIPTION
The object of the program is to:

Take a list of property references from a database
Make a directory for each property reference
Take a list of files
Where filename starts with property reference, move it to its respective folder
Zip the folders

The DBWork branch includes:
Addition of data access layer
Creation of directories based on db content, rather than first part of filenames